### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # E-Commerce Complate Flutter UI Staring code
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fabuanwar072%2FE-commerce-Complete-Flutter-UI&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
 
 ### Note that: This is not complete yet
 


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too. 

Even if you have the YouTube video that will count the views, this is another one as it will tell whether visitors is coming from GitHub or from YouTube.

![Screenshot (1638)](https://user-images.githubusercontent.com/47092464/98442891-b6997300-2142-11eb-90b4-4683bfce5f57.png)
